### PR TITLE
Add support for user location in GA payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Log.CloseAndFlush();
 | FlattenSeparator          | Separator joining nested names when flattening                                                   | `_`     |
 | MaxParamNameLength        | Trim GA parameter names to this length (GA max 40)                                              | `40`    |
 | MaxPropertyParamsPerEvent | Upper bound of parameters added from `LogEvent.Properties` per event                             | `10`    |
+| City                      | The city's name. If the city is in the US, also set country_id and region_id so Google Analytics can properly map the city name to a city ID.                                                   | `null`  |
+| RegionId                  | The ISO 3166 country and subdivision. For example, US-CA, US-AR, CA-BC, GB-LND, CN-HK.                                                   | `null`  |
+| CountryId                 | The country in ISO 3166-1 alpha-2 format. For example, US, AU, ES, FR.                                                   | `null`  |
+| SubcontinentId            | The subcontinent in UN M49 format. For example, 011, 021, 030, 039.                                                   | `null`  |
+| ContinentId               | The continent in UN M49 format. For example, 002, 019, 142, 150.                                                   | `null`  |
+
 
 ### Event Parameters Emitted
 

--- a/Serilog.Sinks.GoogleAnalytics/GoogleAnalyticsOptions.cs
+++ b/Serilog.Sinks.GoogleAnalytics/GoogleAnalyticsOptions.cs
@@ -19,7 +19,7 @@ public class GoogleAnalyticsOptions
     public int BatchSizeLimit { get; set; } = 40; // batches subdivided before send
     public int RetryCount { get; set; } = 2;
 
-    // NEW: control serializing LogEvent.Properties into GA params
+    // control serializing LogEvent.Properties into GA params
     public bool IncludeLogEventProperties { get; set; } = false;
 
     // If set, only these property names are included; otherwise all properties are considered.
@@ -40,4 +40,10 @@ public class GoogleAnalyticsOptions
 
     // Limit how many parameters we add from LogEvent properties to avoid exceeding GA limits.
     public int MaxPropertyParamsPerEvent { get; set; } = 10;
+
+    public string City { get; set; }
+    public string RegionId { get; set; }
+    public string CountryId { get; set; }
+    public string SubcontinentId { get; set; }
+    public string ContinentId { get; set; }
 }

--- a/WpfTestApp/Host.cs
+++ b/WpfTestApp/Host.cs
@@ -48,6 +48,8 @@ internal static class Host
 
                 opts.GlobalParams["app_version"] = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString();
                 opts.GlobalParams["app_country"] = regionInfo.EnglishName;
+
+                opts.CountryId = regionInfo.TwoLetterISORegionName;
             })
             .CreateLogger();
 


### PR DESCRIPTION
#### PR Classification
New feature: Added support for user location details in Google Analytics integration.

#### PR Summary
This pull request introduces the ability to specify and send user location metadata (e.g., city, region, country) to Google Analytics, along with related documentation updates and code cleanup.
- **GoogleAnalyticsOptions.cs**: Added `City`, `RegionId`, `CountryId`, `SubcontinentId`, and `ContinentId` properties for user location details.
- **GoogleAnalyticsSink.cs**: Added methods to include user location in the payload (`HasUserLocation`, `AppendUserLocationField`) and ensured proper trimming/escaping of values.
- **README.md**: Documented the new user location properties and their usage.
- **Host.cs**: Configured `CountryId` using the region's two-letter ISO code.
